### PR TITLE
chore: set spec.required_ruby_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+NEXT
+----
+- Set `required_ruby_version` in the gemspec
+
 v1.1.0 - 2023-03-31
 -------------------
 - Expand requirements to allow using Rack 3.x

--- a/rack-cloudflare_middleware.gemspec
+++ b/rack-cloudflare_middleware.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.add_dependency "faraday", ">= 1.0", "< 3"
   spec.add_dependency "rack", ">= 2", "< 4"
 


### PR DESCRIPTION
Noticed this on the rubygems.org page:

<img width="204" alt="Screenshot 2023-03-31 at 5 40 41 PM" src="https://user-images.githubusercontent.com/263424/229257027-c6f19383-20ea-418a-8186-5887febace44.png">

We use Ruby 2.7 features throughout, so the gem should be clear about its dependencies.