### PR TITLE
fix: cloudflare IP list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/rack/cloudflare_middleware/trusted_ips.rb
+++ b/lib/rack/cloudflare_middleware/trusted_ips.rb
@@ -40,8 +40,8 @@ module Rack
       end
 
       def update!
-        read_network "https://www.cloudflare.com/ips-v4", 4
-        read_network "https://www.cloudflare.com/ips-v6", 6
+        read_network "https://www.cloudflare.com/ips-v4/", 4
+        read_network "https://www.cloudflare.com/ips-v6/", 6
       end
 
       def check_update

--- a/spec/deny_others_spec.rb
+++ b/spec/deny_others_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Rack::CloudflareMiddleware::DenyOthers do
 
   before do
     tips.reset!
-    stub_request(:get, "https://www.cloudflare.com/ips-v4")
+    stub_request(:get, "https://www.cloudflare.com/ips-v4/")
       .to_return(status: 200, body: "1.2.3.0/24\n255.255.255.255/32\n\n")
-    stub_request(:get, "https://www.cloudflare.com/ips-v6")
+    stub_request(:get, "https://www.cloudflare.com/ips-v6/")
       .to_return(status: 200, body: "2001:2003:2003:2004::/64")
     tips.update!
   end

--- a/spec/rewrite_remote_addr_spec.rb
+++ b/spec/rewrite_remote_addr_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Rack::CloudflareMiddleware::RewriteRemoteAddr do
 
   before do
     tips.reset!
-    stub_request(:get, "https://www.cloudflare.com/ips-v4")
+    stub_request(:get, "https://www.cloudflare.com/ips-v4/")
       .to_return(status: 200, body: "1.2.3.0/24\n255.255.255.255/32\n\n")
-    stub_request(:get, "https://www.cloudflare.com/ips-v6")
+    stub_request(:get, "https://www.cloudflare.com/ips-v6/")
       .to_return(status: 200, body: "2001:2003:2003:2004::/64")
     tips.update!
   end

--- a/spec/trusted_ips_spec.rb
+++ b/spec/trusted_ips_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Rack::CloudflareMiddleware::TrustedIps do
 
   describe "#include?" do
     before do
-      stub_request(:get, "https://www.cloudflare.com/ips-v4")
+      stub_request(:get, "https://www.cloudflare.com/ips-v4/")
         .to_return(status: 200, body: "1.2.3.0/24\n255.255.255.255/32\n\n")
-      stub_request(:get, "https://www.cloudflare.com/ips-v6")
+      stub_request(:get, "https://www.cloudflare.com/ips-v6/")
         .to_return(status: 200, body: "2001:2003:2003:2004::/64")
       instance.update!
     end
@@ -28,9 +28,9 @@ RSpec.describe Rack::CloudflareMiddleware::TrustedIps do
 
   describe "#update!" do
     it "works" do
-      s1 = stub_request(:get, "https://www.cloudflare.com/ips-v4")
+      s1 = stub_request(:get, "https://www.cloudflare.com/ips-v4/")
         .to_return(status: 200, body: "1.2.3.0/24\n255.255.255.255/32\n\n")
-      s2 = stub_request(:get, "https://www.cloudflare.com/ips-v6")
+      s2 = stub_request(:get, "https://www.cloudflare.com/ips-v6/")
         .to_return(status: 200, body: "2001:2003:2003:2004::/64")
       expect(instance.include?("1.2.3.1")).to eq false
       instance.update!
@@ -40,9 +40,9 @@ RSpec.describe Rack::CloudflareMiddleware::TrustedIps do
     end
 
     it "does nothing but warn on error" do
-      s1 = stub_request(:get, "https://www.cloudflare.com/ips-v4")
+      s1 = stub_request(:get, "https://www.cloudflare.com/ips-v4/")
         .to_return(status: 500)
-      s2 = stub_request(:get, "https://www.cloudflare.com/ips-v6")
+      s2 = stub_request(:get, "https://www.cloudflare.com/ips-v6/")
         .to_return(status: 500)
       expect(instance).to receive(:warn).twice
       expect(instance.include?("1.2.3.1")).to eq false


### PR DESCRIPTION
Cloudflare changed their IP list from `https://www.cloudflare.com/ips-v4` to `https://www.cloudflare.com/ips-v4/` (note the trailing slash).