### PR TITLE
chore: bump rexml to 3.3.6; drop support for ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+NEXT
+----
+- Drop support for Ruby 2.x
+
 v1.2.1 - 2024-02-23
 -------------------
 - Update cloudflare trusted IP URL to include new required trailing slash

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :development, :test do
   gem "standard", "~> 1"
   gem "pry"
   gem "webmock", "~> 3.19"
-  gem "bundle-audit", "~> 0.1.0"
+  gem "bundler-audit", "~> 0.9.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,6 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    bundle-audit (0.1.0)
-      bundler-audit
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
@@ -44,8 +42,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.9.0)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.6)
+      strscan
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -106,8 +104,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bundle-audit (~> 0.1.0)
   bundler (~> 2)
+  bundler-audit (~> 0.9.0)
   faraday (~> 2.7)
   pry
   rack-cloudflare_middleware!
@@ -119,4 +117,4 @@ DEPENDENCIES
   webmock (~> 3.19)
 
 BUNDLED WITH
-   2.4.7
+   2.5.18

--- a/rack-cloudflare_middleware.gemspec
+++ b/rack-cloudflare_middleware.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.add_dependency "faraday", ">= 1.0", "< 3"
   spec.add_dependency "rack", ">= 2", "< 4"


### PR DESCRIPTION
dependabot couldn't do this because I was requiring `bundle-audit` instead of the correct `bundler-audit`. Gah.
