### PR TITLE
chore: drop support for ruby < 3.1 in rack-cloudflare_middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 NEXT
 ----
-- Drop support for Ruby 2.x
+- Drop support for Ruby <3.1
 
 v1.2.1 - 2024-02-23
 -------------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       method_source (~> 1.0)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (3.1.8)
+    rack (3.1.12)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
@@ -98,7 +98,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -107,6 +107,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/rack-cloudflare_middleware.gemspec
+++ b/rack-cloudflare_middleware.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "faraday", ">= 1.0", "< 3"
   spec.add_dependency "rack", ">= 2", "< 4"


### PR DESCRIPTION
bundle-audit dropped support for ruby<3.1, so our CI is failing. let's also bump our MRV
