### PR TITLE
fix: update rake version in gemspec to match gemfile lock

### DIFF
--- a/rack-cloudflare_middleware.gemspec
+++ b/rack-cloudflare_middleware.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 2", "< 4"
 
   spec.add_development_dependency "bundler", "~> 2"
-  spec.add_development_dependency "rake", "~> 13.3"
+  spec.add_development_dependency "rake", "~> 13.4"
   spec.add_development_dependency "rspec", "~> 3.13"
   spec.add_development_dependency "standard", "~> 1"
 end


### PR DESCRIPTION
<img width="1027" height="73" alt="image" src="https://github.com/user-attachments/assets/e1c66bf6-bd70-49f0-9833-e02a9ca0c333" />

Fixes `bundle install` warning about `Gemfile.lock` having `rake 13.4` while `rack-cloudflare_middleware.gemspec` had `rake 13.3`

This was also causing CI to fail for the Dependabot PR to upgrade `standard`: https://github.com/instrumentl/rack-cloudflare_middleware/pull/140 https://github.com/instrumentl/rack-cloudflare_middleware/actions/runs/27659735620/job/81801466589?pr=140

<img width="5066" height="2572" alt="image" src="https://github.com/user-attachments/assets/2a9c0dbf-4643-4759-a971-e634a6945ce2" />