### PR TITLE
chore(deps): upgrade faraday to eliminate CVE-2026-54297

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.6.2)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
`faraday 2.14.2` has CVE-2026-54297 and `bundle audit check` in CI is failing in this repo

<img width="5066" height="2572" alt="image" src="https://github.com/user-attachments/assets/00ca8e70-1c74-479c-8ca7-ded758a0d5c4" />